### PR TITLE
feat: hide dock icon in macOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from utils.credential_utils import save_credentials
 from utils.connection_utils import start_connection, stop_connection
 from utils.common import get_resource_path, get_version
 from utils.password_utils import toggle_password_visibility
-from utils.menu_utils import setup_menubar, check_for_updates
+from utils.menu_utils import setup_menubar, check_for_updates, hide_dock_icon
 from utils.config_utils import load_settings
 
 VERSION = get_version()
@@ -120,6 +120,7 @@ if __name__ == "__main__":
         icon_path = get_resource_path("assets/icon.ico")
     elif system() == "Darwin":
         icon_path = get_resource_path("assets/icon.icns")
+        hide_dock_icon()
     elif system() == "Linux":
         icon_path = get_resource_path("assets/icon.png")
     app_icon = QIcon(icon_path)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ from utils.credential_utils import save_credentials
 from utils.connection_utils import start_connection, stop_connection
 from utils.common import get_resource_path, get_version
 from utils.password_utils import toggle_password_visibility
-from utils.menu_utils import setup_menubar, check_for_updates, hide_dock_icon
+from utils.menu_utils import setup_menubar, check_for_updates
+from utils.macos_utils import hide_dock_icon
 from utils.config_utils import load_settings
 
 VERSION = get_version()
@@ -22,8 +23,8 @@ class MainWindow(QMainWindow):
         self.setMinimumSize(300, 450) 
         
         self.worker = None
-        setup_menubar(self, VERSION)
         self.load_settings()
+        setup_menubar(self, VERSION)
         self.setup_ui()
         self.tray_icon = init_tray_icon(self)
         
@@ -121,12 +122,16 @@ if __name__ == "__main__":
         icon_path = get_resource_path("assets/icon.ico")
     elif system() == "Darwin":
         icon_path = get_resource_path("assets/icon.icns")
-        hide_dock_icon(window.hide_dock_icon)
     elif system() == "Linux":
         icon_path = get_resource_path("assets/icon.png")
+
     app_icon = QIcon(icon_path)
     app.setWindowIcon(app_icon)
     
     if not window.silent_mode:
         window.show()
+    
+    if system() == "Darwin":
+        hide_dock_icon(window.hide_dock_icon)
+
     app.exec()

--- a/main.py
+++ b/main.py
@@ -115,18 +115,18 @@ class MainWindow(QMainWindow):
 if __name__ == "__main__":
     app = QApplication([])
     app.setQuitOnLastWindowClosed(False)
+    window = MainWindow() 
     
     if system() == "Windows":
         icon_path = get_resource_path("assets/icon.ico")
     elif system() == "Darwin":
         icon_path = get_resource_path("assets/icon.icns")
-        hide_dock_icon()
+        hide_dock_icon(window.hide_dock_icon)
     elif system() == "Linux":
         icon_path = get_resource_path("assets/icon.png")
     app_icon = QIcon(icon_path)
     app.setWindowIcon(app_icon)
     
-    window = MainWindow()
     if not window.silent_mode:
         window.show()
     app.exec()

--- a/utils/advanced_panel.py
+++ b/utils/advanced_panel.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QCheckBox, QPushButton, QHBoxLayout
 from .config_utils import save_config, load_config
 from .startup_utils import set_launch_at_login, get_launch_at_login
+from platform import system
 
 class AdvancedSettingsDialog(QDialog):
     def __init__(self, parent=None):
@@ -43,6 +44,11 @@ class AdvancedSettingsDialog(QDialog):
         self.check_update_switch = QCheckBox("启动时检查更新")
         layout.addWidget(self.check_update_switch)
 
+        # Hide dock icon option (only for macOS)
+        if system() == "Darwin":
+            self.hide_dock_icon_switch = QCheckBox("隐藏 Dock 图标")
+            layout.addWidget(self.hide_dock_icon_switch)
+
         # Buttons
         button_layout = QHBoxLayout()
         save_button = QPushButton("保存")
@@ -57,7 +63,7 @@ class AdvancedSettingsDialog(QDialog):
         self.setLayout(layout)
 
     def get_settings(self):
-        return {
+        settings = {
             'server': self.server_input.text(),
             'dns': self.dns_input.text(),
             'proxy': self.proxy_switch.isChecked(),
@@ -65,8 +71,13 @@ class AdvancedSettingsDialog(QDialog):
             'silent_mode': self.silent_mode_switch.isChecked(),
             'check_update': self.check_update_switch.isChecked()
         }
+        
+        if system() == "Darwin":
+            settings['hide_dock_icon'] = self.hide_dock_icon_switch.isChecked()
+            
+        return settings
     
-    def set_settings(self, server, dns, proxy, connect_startup, silent_mode, check_update):
+    def set_settings(self, server, dns, proxy, connect_startup, silent_mode, check_update, hide_dock_icon=False):
         """Set dialog values from main window values"""
         self.server_input.setText(server)
         self.dns_input.setText(dns)
@@ -74,6 +85,8 @@ class AdvancedSettingsDialog(QDialog):
         self.connect_startup_switch.setChecked(connect_startup)
         self.silent_mode_switch.setChecked(silent_mode)
         self.check_update_switch.setChecked(check_update)
+        if system() == "Darwin":
+            self.hide_dock_icon_switch.setChecked(hide_dock_icon)
 
     def accept(self):
         """Save settings before closing"""

--- a/utils/advanced_panel.py
+++ b/utils/advanced_panel.py
@@ -2,6 +2,10 @@ from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QCheckBox
 from .config_utils import save_config, load_config
 from .startup_utils import set_launch_at_login, get_launch_at_login
 from platform import system
+from .macos_utils import hide_dock_icon
+from .common import get_version
+
+VERSION = get_version()
 
 class AdvancedSettingsDialog(QDialog):
     def __init__(self, parent=None):
@@ -99,4 +103,8 @@ class AdvancedSettingsDialog(QDialog):
         
         save_config(settings)
         set_launch_at_login(enable=self.startup_switch.isChecked())
+        
+        if system() == "Darwin":
+            hide_dock_icon(self.hide_dock_icon_switch.isChecked())
+
         super().accept()

--- a/utils/advanced_panel.py
+++ b/utils/advanced_panel.py
@@ -1,9 +1,10 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QCheckBox, QPushButton, QHBoxLayout
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QCheckBox, QPushButton, QHBoxLayout, QApplication
+from PySide6.QtGui import QIcon
 from .config_utils import save_config, load_config
 from .startup_utils import set_launch_at_login, get_launch_at_login
 from platform import system
 from .macos_utils import hide_dock_icon
-from .common import get_version
+from utils.common import get_resource_path, get_version
 
 VERSION = get_version()
 
@@ -106,5 +107,19 @@ class AdvancedSettingsDialog(QDialog):
         
         if system() == "Darwin":
             hide_dock_icon(self.hide_dock_icon_switch.isChecked())
+            
+            from .menu_utils import setup_menubar
+            main_window = self.parent()
+            main_window.hide_dock_icon = self.hide_dock_icon_switch.isChecked()
+            setup_menubar(main_window, VERSION)
+
+            main_window.show()
+            main_window.raise_()
+            
+            icon_path = get_resource_path("assets/icon.icns")
+
+            app_icon = QIcon(icon_path)
+            app = QApplication.instance()
+            app.setWindowIcon(app_icon)
 
         super().accept()

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -24,7 +24,8 @@ def load_config():
         'launch_at_login': get_launch_at_login(),
         'connect_startup': False,
         'silent_mode': False,
-        'check_update': True
+        'check_update': True,
+        'hide_dock_icon': False
     }
     
     try:
@@ -48,3 +49,4 @@ def load_settings(self):
     self.connect_startup = config['connect_startup']
     self.silent_mode = config['silent_mode']
     self.check_update = config['check_update']
+    self.hide_dock_icon = config.get('hide_dock_icon')

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -49,4 +49,4 @@ def load_settings(self):
     self.connect_startup = config['connect_startup']
     self.silent_mode = config['silent_mode']
     self.check_update = config['check_update']
-    self.hide_dock_icon = config.get('hide_dock_icon')
+    self.hide_dock_icon = config['hide_dock_icon']

--- a/utils/macos_utils.py
+++ b/utils/macos_utils.py
@@ -1,0 +1,8 @@
+import objc
+from platform import system
+
+def hide_dock_icon(hide=True):
+    """ 使用 macOS API 控制 Dock 图标显示状态 """
+    if system() == "Darwin":
+        NSApp = objc.lookUpClass("NSApplication").sharedApplication()
+        NSApp.setActivationPolicy_(1 if hide else 0)  # 1 = NSApplicationActivationPolicyAccessory, 0 = NSApplicationActivationPolicyRegular

--- a/utils/macos_utils.py
+++ b/utils/macos_utils.py
@@ -2,7 +2,7 @@ import objc
 from platform import system
 
 def hide_dock_icon(hide=True):
-    """ 使用 macOS API 控制 Dock 图标显示状态 """
+    """ Control the visibility of the app icon in the dock using macOS API """
     if system() == "Darwin":
         NSApp = objc.lookUpClass("NSApplication").sharedApplication()
         NSApp.setActivationPolicy_(1 if hide else 0)  # 1 = NSApplicationActivationPolicyAccessory, 0 = NSApplicationActivationPolicyRegular

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -19,7 +19,7 @@ def setup_menubar(window: QMainWindow, version):
     
     # Settings Menu
     settings_menu = menubar.addMenu("设置")
-    window.advanced_action = settings_menu.addAction("高级设置   ")
+    window.advanced_action = settings_menu.addAction("高级设置" + (" " * 5 if system() == "Darwin" else ""))
     if system() == "Darwin":
         window.advanced_action.setShortcut(QKeySequence(Qt.CTRL | Qt.Key_Comma))  # Command + ,
     window.advanced_action.triggered.connect(lambda: show_advanced_settings(window))

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -116,7 +116,8 @@ def show_advanced_settings(window):
         window.proxy,
         window.connect_startup,
         window.silent_mode,
-        window.check_update
+        window.check_update,
+        window.hide_dock_icon
     )
     
     if dialog.exec():
@@ -127,8 +128,12 @@ def show_advanced_settings(window):
         window.connect_startup = settings['connect_startup']
         window.silent_mode = settings['silent_mode']
         window.check_update = settings['check_update']
+        window.hide_dock_icon = settings.get('hide_dock_icon', False)
+        if system() == "Darwin":
+            hide_dock_icon(window.hide_dock_icon)
 
-def hide_dock_icon():
-    """ 使用 macOS API 让应用变为后台模式，不显示 Dock 图标 """
-    NSApp = objc.lookUpClass("NSApplication").sharedApplication()
-    NSApp.setActivationPolicy_(1)  # 1 = NSApplicationActivationPolicyAccessory
+def hide_dock_icon(hide=True):
+    """ 使用 macOS API 控制 Dock 图标显示状态 """
+    if system() == "Darwin":
+        NSApp = objc.lookUpClass("NSApplication").sharedApplication()
+        NSApp.setActivationPolicy_(1 if hide else 0)  # 1 = NSApplicationActivationPolicyAccessory, 0 = NSApplicationActivationPolicyRegular

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QMessageBox, QDialog, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox, QMainWindow, QMenuBar
-from PySide6.QtGui import QGuiApplication
+from PySide6.QtGui import QGuiApplication, QKeySequence
 import requests
 import objc
 from packaging import version
@@ -11,17 +11,17 @@ from platform import system
 def setup_menubar(window: QMainWindow, version):
     """Set up the main window menu bar"""
     if system() == "Darwin":
-        # 在 macOS 上创建非原生菜单栏
         menubar = QMenuBar(window)
         menubar.setNativeMenuBar(False)  # 让菜单栏出现在窗口内部
         window.setMenuBar(menubar)
     else:
-        # 在其他平台上使用默认菜单栏
         menubar = window.menuBar()
     
     # Settings Menu
     settings_menu = menubar.addMenu("设置")
-    window.advanced_action = settings_menu.addAction("高级设置")
+    window.advanced_action = settings_menu.addAction("高级设置   ")
+    if system() == "Darwin":
+        window.advanced_action.setShortcut(QKeySequence(Qt.CTRL | Qt.Key_Comma))  # Command + ,
     window.advanced_action.triggered.connect(lambda: show_advanced_settings(window))
     
     # Help Menu

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -12,7 +12,7 @@ def setup_menubar(window: QMainWindow, version):
     """Set up the main window menu bar"""
     if system() == "Darwin":
         menubar = QMenuBar(window)
-        menubar.setNativeMenuBar(False)  # 让菜单栏出现在窗口内部
+        menubar.setNativeMenuBar(not window.hide_dock_icon)
         window.setMenuBar(menubar)
     else:
         menubar = window.menuBar()

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -1,14 +1,23 @@
-from PySide6.QtWidgets import QMessageBox, QDialog, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox, QMainWindow
+from PySide6.QtWidgets import QMessageBox, QDialog, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox, QMainWindow, QMenuBar
 from PySide6.QtGui import QGuiApplication
 import requests
+import objc
 from packaging import version
 import webbrowser
 from PySide6.QtCore import Qt
 from .advanced_panel import AdvancedSettingsDialog
+from platform import system
 
 def setup_menubar(window: QMainWindow, version):
     """Set up the main window menu bar"""
-    menubar = window.menuBar()
+    if system() == "Darwin":
+        # 在 macOS 上创建非原生菜单栏
+        menubar = QMenuBar(window)
+        menubar.setNativeMenuBar(False)  # 让菜单栏出现在窗口内部
+        window.setMenuBar(menubar)
+    else:
+        # 在其他平台上使用默认菜单栏
+        menubar = window.menuBar()
     
     # Settings Menu
     settings_menu = menubar.addMenu("设置")
@@ -118,3 +127,8 @@ def show_advanced_settings(window):
         window.connect_startup = settings['connect_startup']
         window.silent_mode = settings['silent_mode']
         window.check_update = settings['check_update']
+
+def hide_dock_icon():
+    """ 使用 macOS API 让应用变为后台模式，不显示 Dock 图标 """
+    NSApp = objc.lookUpClass("NSApplication").sharedApplication()
+    NSApp.setActivationPolicy_(1)  # 1 = NSApplicationActivationPolicyAccessory

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -1,7 +1,6 @@
 from PySide6.QtWidgets import QMessageBox, QDialog, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox, QMainWindow, QMenuBar
 from PySide6.QtGui import QGuiApplication, QKeySequence
 import requests
-import objc
 from packaging import version
 import webbrowser
 from PySide6.QtCore import Qt

--- a/utils/menu_utils.py
+++ b/utils/menu_utils.py
@@ -7,6 +7,7 @@ import webbrowser
 from PySide6.QtCore import Qt
 from .advanced_panel import AdvancedSettingsDialog
 from platform import system
+from .macos_utils import hide_dock_icon
 
 def setup_menubar(window: QMainWindow, version):
     """Set up the main window menu bar"""
@@ -131,9 +132,3 @@ def show_advanced_settings(window):
         window.hide_dock_icon = settings.get('hide_dock_icon', False)
         if system() == "Darwin":
             hide_dock_icon(window.hide_dock_icon)
-
-def hide_dock_icon(hide=True):
-    """ 使用 macOS API 控制 Dock 图标显示状态 """
-    if system() == "Darwin":
-        NSApp = objc.lookUpClass("NSApplication").sharedApplication()
-        NSApp.setActivationPolicy_(1 if hide else 0)  # 1 = NSApplicationActivationPolicyAccessory, 0 = NSApplicationActivationPolicyRegular


### PR DESCRIPTION
## 📝 描述

macOS 的 Dock 栏寸土寸金，这类网络相关 app 一般作为后台程序，并不常驻在 Dock 栏中。这里把该 app 修改为 Accessory 模式，不在 Dock 和 Command+Tab 应用切换器 中显示。

而 Accessory 模式时 app 不会有原生菜单栏，因此重新把菜单栏加回到面板内部：
<img width="412" alt="image" src="https://github.com/user-attachments/assets/a3a1fcad-91fa-4c72-ac9d-c70e9fcde3df" />

同时增加了macOS常用的 `command + ,` 的打开设置快捷键。（其实可以给别的OS也加一下快捷键）

btw，你的pr模板没有根据这个项目修改过哈，看起来还是课程共享的文档。
