### PR TITLE
feat: use Microsoft YaHei UI as the application font for Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,9 @@ if __name__ == "__main__":
     
     if system() == "Windows":
         icon_path = get_resource_path("assets/icon.ico")
+        font = app.font()
+        font.setFamily("Microsoft YaHei UI")
+        app.setFont(font)
     elif system() == "Darwin":
         icon_path = get_resource_path("assets/icon.icns")
     elif system() == "Linux":

--- a/main_fluent.py
+++ b/main_fluent.py
@@ -130,6 +130,9 @@ if __name__ == "__main__":
     
     if system() == "Windows":
         icon_path = get_resource_path("assets/icon.ico")
+        font = app.font()
+        font.setFamily("Microsoft YaHei UI")
+        app.setFont(font)
     elif system() == "Darwin":
         icon_path = get_resource_path("assets/icon.icns")
     elif system() == "Linux":


### PR DESCRIPTION
在非简体中文版的 Windows 系统上，如果不指定字体，中文的显示效果很奇怪：

![image](https://github.com/user-attachments/assets/0feff11d-7d76-42e4-8ab9-bee8ac3703ed)

设置字体后的效果：

![image](https://github.com/user-attachments/assets/0a20b041-c6dd-4a82-a6a2-14f6ae5d0847)