### PR TITLE
Experiment: add support for Linux Arm64 by using QEMU in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             arch: arm64
             use_emulation: true
             container_arch: aarch64
-            container_distro: ubuntu22.04
+            container_distro: ubuntu24.04
             
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,19 +179,19 @@ jobs:
           apt-get install -q -y \
             curl \
             unzip
+
+        run: |
           # Install uv
           curl -LsSf https://astral.sh/uv/install.sh | sh
           source $HOME/.local/bin/env
           uv python install 3.11  # specified Python version
+          uv sync
+          source .venv/bin/activate
 
-        run: |
           curl -L "https://github.com/Mythologyli/zju-connect/releases/latest/download/zju-connect-linux-arm64.zip" -o core/zju-connect.zip
           unzip -o core/zju-connect.zip -d core
           rm core/zju-connect.zip
-          
-          # Install dependencies using uv
-          uv sync
-          
+
           pyinstaller --noconsole --clean --onefile \
             --add-data "assets:assets" \
             --add-data "utils:utils" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           - os: ubuntu-latest
             os_name: linux
             arch: amd64
+          - os: ubuntu-latest
+            os_name: linux
+            arch: arm64
+            use_emulation: true
+            container_arch: aarch64
+            container_distro: ubuntu22.04
             
     runs-on: ${{ matrix.os }}
 
@@ -128,13 +134,13 @@ jobs:
              installer.iss
 
     - name: Install Linux Dependencies
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.arch == 'amd64'
       run: |
         sudo apt-get update
         sudo apt-get install -y libglib2.0-0 libgl1 dpkg-dev debhelper
 
-    - name: Build Executable (Linux)
-      if: runner.os == 'Linux'
+    - name: Build Executable (Linux AMD64)
+      if: runner.os == 'Linux' && matrix.arch == 'amd64'
       run: |
         source .venv/bin/activate        
         mkdir -p core
@@ -149,6 +155,42 @@ jobs:
           --add-data ".app-version:." \
           --icon assets/icon.png \
           -n hitsz-connect-verge main.py
+
+    - name: Build Executable (Linux ARM64)
+      if: runner.os == 'Linux' && matrix.arch == 'arm64'
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: ${{ matrix.container_arch }}
+        distro: ${{ matrix.container_distro }}
+        githubToken: ${{ github.token }}
+        
+        setup: |
+          mkdir -p "${PWD}/dist"
+          mkdir -p "${PWD}/core"
+
+        dockerRunArgs: |
+          --volume "${PWD}/dist:/dist"
+          --volume "${PWD}/core:/core"
+          --volume "${PWD}:/workspace"
+          --workdir /workspace
+
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y python3-pip python3-dev libglib2.0-0 libgl1 curl unzip
+          pip3 install -U pip pyinstaller
+
+        run: |
+          curl -L "https://github.com/Mythologyli/zju-connect/releases/latest/download/zju-connect-linux-arm64.zip" -o core/zju-connect.zip
+          unzip -o core/zju-connect.zip -d core
+          rm core/zju-connect.zip
+          
+          pyinstaller --noconsole --clean --onefile \
+            --add-data "assets:assets" \
+            --add-data "utils:utils" \
+            --add-data "core/zju-connect:core" \
+            --add-data ".app-version:." \
+            --icon assets/icon.png \
+            -n hitsz-connect-verge main.py
 
     - name: Archive Executable
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
             unzip
           # Install uv
           curl -LsSf https://astral.sh/uv/install.sh | sh
+          source $HOME/.local/bin/env
           uv python install 3.11  # specified Python version
 
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,13 +176,20 @@ jobs:
 
         install: |
           apt-get update -q -y
-          apt-get install -q -y python3-pip python3-dev libglib2.0-0 libgl1 curl unzip
-          pip3 install -U pip pyinstaller
+          apt-get install -q -y \
+            curl \
+            unzip
+          # Install uv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install 3.11  # specified Python version
 
         run: |
           curl -L "https://github.com/Mythologyli/zju-connect/releases/latest/download/zju-connect-linux-arm64.zip" -o core/zju-connect.zip
           unzip -o core/zju-connect.zip -d core
           rm core/zju-connect.zip
+          
+          # Install dependencies using uv
+          uv sync
           
           pyinstaller --noconsole --clean --onefile \
             --add-data "assets:assets" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,22 @@ jobs:
     - name: Install Dependencies
       run: uv sync
 
+    - name: Cache Chocolatey packages
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: C:\Users\RUNNER~1\AppData\Local\Temp\chocolatey
+        key: ${{ runner.os }}-chocolatey-${{ hashFiles('**/*.iss') }}
+        restore-keys: |
+          ${{ runner.os }}-chocolatey-
+
+    - name: Cache apt packages
+      if: runner.os == 'Linux'
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-${{ hashFiles('**/release.yml') }}
+
     - name: Build Executable (macOS)
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/release.yml` file to enhance the build process by adding support for ARM64 architecture and improving caching mechanisms.

### Enhancements to build process:

* Added support for building on ARM64 architecture by including a new job matrix entry for `arm64` and configuring the necessary emulation and container settings.
* Introduced a new job to build executables specifically for Linux ARM64, utilizing `uraimo/run-on-arch-action@v2` for cross-compilation.

### Improvements to caching:

* Added steps to cache Chocolatey packages on Windows runners to speed up subsequent runs.
* Implemented caching for apt packages on Linux runners to reduce dependency installation time.
