### PR TITLE
feat: New feature to disable automatic selection of optimal route

### DIFF
--- a/app/utils/config_utils.py
+++ b/app/utils/config_utils.py
@@ -26,6 +26,7 @@ def load_config():
         'hide_dock_icon': False,
         'keep_alive': True,
         'debug_dump': False,
+        'disable_multi_line': False,
         'socks_bind': '1080',
         'http_bind': '1081',
     }
@@ -55,5 +56,6 @@ def load_settings(self):
     self.hide_dock_icon = config['hide_dock_icon']
     self.keep_alive = config['keep_alive']
     self.debug_dump = config['debug_dump']
+    self.disable_multi_line = config['disable_multi_line']
     self.http_bind = config['http_bind']
     self.socks_bind = config['socks_bind']

--- a/app/utils/connection_utils.py
+++ b/app/utils/connection_utils.py
@@ -69,6 +69,9 @@ def start_connection(window):
     if window.debug_dump:
         command_args.append("-debug-dump")
 
+    if window.disable_multi_line:
+        command_args.append("-disable-multi-line")
+
     command_args.append("-disable-zju-config")
     command_args.append("-skip-domain-resource")
     command_args.extend(["-zju-dns-server", "auto"])

--- a/app/views/advanced_panel.py
+++ b/app/views/advanced_panel.py
@@ -75,6 +75,10 @@ class AdvancedSettingsDialog(QDialog):
         self.debug_dump_switch = QCheckBox("调试模式")
         network_layout.addWidget(self.debug_dump_switch)
 
+        # Disable multi line
+        self.disable_multi_line_switch = QCheckBox("禁用备用线路检测")
+        network_layout.addWidget(self.disable_multi_line_switch)
+
         network_tab.setLayout(network_layout)
         
         # General tab
@@ -134,6 +138,7 @@ class AdvancedSettingsDialog(QDialog):
             'check_update': self.check_update_switch.isChecked(),
             'keep_alive': self.keep_alive_switch.isChecked(),
             'debug_dump': self.debug_dump_switch.isChecked(),
+            'disable_multi_line': self.disable_multi_line_switch.isChecked(),
             'http_bind': self.http_bind_input.text(),
             'socks_bind': self.socks_bind_input.text(),
         }
@@ -143,7 +148,7 @@ class AdvancedSettingsDialog(QDialog):
             
         return settings
     
-    def set_settings(self, server, port, dns, proxy, connect_startup, silent_mode, check_update, hide_dock_icon=False, keep_alive=False, debug_dump=False, http_bind='', socks_bind=''):
+    def set_settings(self, server, port, dns, proxy, connect_startup, silent_mode, check_update, hide_dock_icon=False, keep_alive=False, debug_dump=False, disable_multi_line=False, http_bind='', socks_bind=''):
         """Set dialog values from main window values"""
         self.server_input.setText(server)
         self.port_input.setText(port)
@@ -156,6 +161,7 @@ class AdvancedSettingsDialog(QDialog):
             self.hide_dock_icon_switch.setChecked(hide_dock_icon)
         self.keep_alive_switch.setChecked(keep_alive)
         self.debug_dump_switch.setChecked(debug_dump)
+        self.disable_multi_line_switch.setChecked(disable_multi_line)
         self.http_bind_input.setText(http_bind)
         self.socks_bind_input.setText(socks_bind)
 

--- a/app/views/menu_utils.py
+++ b/app/views/menu_utils.py
@@ -96,6 +96,7 @@ def show_advanced_settings(window):
         window.hide_dock_icon,
         window.keep_alive,
         window.debug_dump,
+        window.disable_multi_line,
         window.http_bind,
         window.socks_bind
     )
@@ -112,6 +113,7 @@ def show_advanced_settings(window):
         window.hide_dock_icon = settings.get('hide_dock_icon', False)
         window.keep_alive = settings['keep_alive']
         window.debug_dump = settings['debug_dump']
+        window.disable_multi_line = settings['disable_multi_line']
         window.http_bind = settings['http_bind']
         window.socks_bind = settings['socks_bind']
         if system() == "Darwin":


### PR DESCRIPTION
<!--
感谢你参与维护本仓库！为了能让你的 PR 能够快速被审核，请按照以下模版填写 PR 的内容。

如果这是你的第一次提交，请先抽出少量时间阅读我们的[《参与指南》](https://hoa.moe/blog/contribution-guide/)
-->

## 📝 描述

新增了一个 “禁用自动根据延时选择线路” 的功能，可以避免因为VPN服务器的备用线路故障而导致无法正常使用的问题。
使用的是 [zju-connect](https://github.com/Mythologyli/zju-connect) 中的 disable-multi-line 参数

## ✅ 检查清单

<!-- 在提交 PR 之前，请检查以下事项。如果只是文档的编写/修改，可以不用填写。 -->

- [x] 我已知晓并认同 [《参与指南》](https://hoa.moe/blog/contribution-guide/) 中的内容公约和格式公约。

- [x] 是否在合适的文件夹上传？

<!-- 仓库惯例：assignments: 课程作业 - exams: 考试题 - labs：实验报告 - notes：笔记 -->

- [x] 是否获得了必要的许可？

<!-- 如果是转载的文章，请务必申请原作者的许可并注明出处。对于其他上传的文件，我们不强制要求获得许可，但是请尊重原作者的知识产权。 -->

- [x] 文件命名是否符合规范？

<!-- 所有上传的文件/文件夹的命名都应该包含以下信息：署名以及对应课程的开课时间，例如： 2021_YumingLi。-->

## 📢 通知成员

<!--
由于 GitHub 不支持非成员直接 assign 成员，因此请贡献者手动 @ 成员作为额外提醒，这样方便快速通过 PR。最好是按照年级来 @，也可以找仓库的历史贡献者，因为贡献者通常对内容比较熟悉。

19 级 @lmh12138
20 级 @TangLongbin
21 级 @OliverWu515 @Co-ding-Man
22 级 @MaxwellJay256 @longlin10086 @AutoFriedRich
23 级 @IcyDesert @WDGaster703 @YinMo19
-->

## 🤔 附加信息

<!-- 请添加任何你认为有帮助的信息,如果没有，请删去该节 -->
