### PR TITLE
fix: add auto DNS configuration option in advanced settings

### DIFF
--- a/app/utils/config_utils.py
+++ b/app/utils/config_utils.py
@@ -18,6 +18,7 @@ def load_config():
         'server': 'vpn.hitsz.edu.cn',
         'port': '443',
         'dns': '10.248.98.30',
+        'auto_dns': True,
         'proxy': True,
         'launch_at_login': get_launch_at_login(),
         'connect_startup': False,
@@ -49,6 +50,7 @@ def load_settings(self):
     self.server_address = config['server']
     self.port = config['port']
     self.dns_server = config['dns']
+    self.auto_dns = config['auto_dns']
     self.proxy = config['proxy']
     self.connect_startup = config['connect_startup']
     self.silent_mode = config['silent_mode']

--- a/app/utils/connection_utils.py
+++ b/app/utils/connection_utils.py
@@ -52,10 +52,15 @@ def start_connection(window):
         command,
         "-server", shlex.quote(server_address),
         "-port", shlex.quote(str(port)),
-        "-zju-dns-server", shlex.quote(dns_server_address),
         "-username", shlex.quote(username),
         "-password", shlex.quote(password)
     ]
+    
+    # Add DNS server configuration
+    if window.auto_dns:
+        command_args.extend(["-zju-dns-server", "auto"])
+    else:
+        command_args.extend(["-zju-dns-server", shlex.quote(dns_server_address)])
     
     if window.http_bind:
         command_args.extend(["-http-bind", shlex.quote("127.0.0.1:" + window.http_bind)])
@@ -74,7 +79,6 @@ def start_connection(window):
 
     command_args.append("-disable-zju-config")
     command_args.append("-skip-domain-resource")
-    command_args.extend(["-zju-dns-server", "auto"])
     
     debug_command = command_args.copy()
     username_index = debug_command.index("-username") + 1

--- a/app/views/advanced_panel.py
+++ b/app/views/advanced_panel.py
@@ -43,6 +43,10 @@ class AdvancedSettingsDialog(QDialog):
         dns_layout.addWidget(QLabel("DNS 服务器地址"))
         self.dns_input = QLineEdit("10.248.98.30")
         dns_layout.addWidget(self.dns_input)
+        self.auto_dns_switch = QCheckBox("自动配置 DNS")
+        self.auto_dns_switch.setChecked(True)
+        self.auto_dns_switch.toggled.connect(self.toggle_dns_input)
+        dns_layout.addWidget(self.auto_dns_switch)
         network_layout.addLayout(dns_layout)
         
         # SOCKS bind
@@ -127,11 +131,16 @@ class AdvancedSettingsDialog(QDialog):
         
         self.setLayout(layout)
 
+    def toggle_dns_input(self):
+        """Toggle DNS input field based on auto DNS checkbox"""
+        self.dns_input.setEnabled(not self.auto_dns_switch.isChecked())
+        
     def get_settings(self):
         settings = {
             'server': self.server_input.text(),
             'port': self.port_input.text(),
             'dns': self.dns_input.text(),
+            'auto_dns': self.auto_dns_switch.isChecked(),
             'proxy': self.proxy_switch.isChecked(),
             'connect_startup': self.connect_startup_switch.isChecked(),
             'silent_mode': self.silent_mode_switch.isChecked(),
@@ -148,11 +157,12 @@ class AdvancedSettingsDialog(QDialog):
             
         return settings
     
-    def set_settings(self, server, port, dns, proxy, connect_startup, silent_mode, check_update, hide_dock_icon=False, keep_alive=False, debug_dump=False, disable_multi_line=False, http_bind='', socks_bind=''):
+    def set_settings(self, server, port, dns, proxy, connect_startup, silent_mode, check_update, hide_dock_icon=False, keep_alive=False, debug_dump=False, disable_multi_line=False, http_bind='', socks_bind='', auto_dns=True):
         """Set dialog values from main window values"""
         self.server_input.setText(server)
         self.port_input.setText(port)
         self.dns_input.setText(dns)
+        self.auto_dns_switch.setChecked(auto_dns)
         self.proxy_switch.setChecked(proxy)
         self.connect_startup_switch.setChecked(connect_startup)
         self.silent_mode_switch.setChecked(silent_mode)
@@ -164,6 +174,9 @@ class AdvancedSettingsDialog(QDialog):
         self.disable_multi_line_switch.setChecked(disable_multi_line)
         self.http_bind_input.setText(http_bind)
         self.socks_bind_input.setText(socks_bind)
+        
+        # Enable/disable DNS input based on auto DNS setting
+        self.toggle_dns_input()
 
     def accept(self):
         """Save settings before closing"""

--- a/app/views/menu_utils.py
+++ b/app/views/menu_utils.py
@@ -98,7 +98,8 @@ def show_advanced_settings(window):
         window.debug_dump,
         window.disable_multi_line,
         window.http_bind,
-        window.socks_bind
+        window.socks_bind,
+        window.auto_dns
     )
     
     if dialog.exec():
@@ -106,6 +107,7 @@ def show_advanced_settings(window):
         window.server_address = settings['server']
         window.port = settings['port']
         window.dns_server = settings['dns']
+        window.auto_dns = settings['auto_dns']
         window.proxy = settings['proxy']
         window.connect_startup = settings['connect_startup']
         window.silent_mode = settings['silent_mode']


### PR DESCRIPTION
In older version, `-zju-connect-server` will use user input DNS and "auto" at the same time, which is not a correct logic. This PR hopes to fix the issue.