### PR TITLE
fix: add leading space to DEB control Description continuation line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           Architecture: ${{ matrix.arch == 'amd64' && 'amd64' || 'arm64' }}
           Maintainer: Kowyo
           Description: HITSZ Connect Verge
-          A VPN client for ZJU Connect/EasyConnect users.
+           A VPN client for ZJU Connect/EasyConnect users.
           Depends: libc6, libglib2.0-0, libgl1
           EOF
 


### PR DESCRIPTION
## Summary

- The Debian control file `Description` field had a continuation line (`A VPN client...`) without a leading space
- In Debian RFC 822 control format, continuation lines **must** start with at least one space/tab; without it, `dpkg-deb` tries to parse `A` as a new field name and fails
- The YAML `|` block scalar strips common indentation, so what appeared indented in the YAML was actually zero-indented in the generated script

## Fix

Added one extra space before `A VPN client for ZJU Connect/EasyConnect users.` so that after YAML indentation stripping, it becomes a valid continuation line (starts with a space).

## Test plan

- [ ] Trigger a Linux build and confirm the `Create DEB Package` step completes without the `field name 'A' must be followed by colon` error

https://claude.ai/code/session_017TqfF17sptnhk1U1yXYVrR